### PR TITLE
Make telegram-rs buildable on stable

### DIFF
--- a/examples/create_auth_key/Cargo.toml
+++ b/examples/create_auth_key/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.0.0"
 workspace = "../../"
 
 [dependencies]
+extprim = "1.4.0"
+extprim_literals = "2.0.3"
 telegram = { path = "../../telegram" }
 hyper = "0.10"

--- a/examples/create_auth_key/src/main.rs
+++ b/examples/create_auth_key/src/main.rs
@@ -1,13 +1,16 @@
-extern crate telegram;
+extern crate extprim;
+#[macro_use] extern crate extprim_literals;
 extern crate hyper;
+extern crate telegram;
+
+use std::io::Read;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use hyper::Client;
 use hyper::client::Body;
 use hyper::header::{ContentLength, Connection};
-
 use telegram::ser::Serialize;
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::io::Read;
+
 
 fn main() {
     // Request for (p,q) Authorization
@@ -17,7 +20,7 @@ fn main() {
     println!(" * Request for (p,q) Authorization");
 
     let req_pq = telegram::schema::mtproto::req_pq {
-        nonce: 0x3E0549828CCA27E966B301A48FECE2FC,
+        nonce: i128!(0x3E0549828CCA27E966B301A48FECE2FC),
     };
 
     // [DEBUG] Step

--- a/telegram/Cargo.toml
+++ b/telegram/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/mehcode/telegram-rs"
 [dependencies]
 byteorder = "1.0.0"
 error-chain = "0.9.0"
+extprim = "1.4.0"
 telegram_derive = "0.1.0"
 
 [build-dependencies]

--- a/telegram/src/lib.rs
+++ b/telegram/src/lib.rs
@@ -1,14 +1,7 @@
-#![feature(i128_type)]
-#![feature(concat_idents)]
-#![feature(attr_literals)]
-
 extern crate byteorder;
-
-#[macro_use]
-extern crate telegram_derive;
-
-#[macro_use]
-extern crate error_chain;
+#[macro_use] extern crate error_chain;
+extern crate extprim;
+#[macro_use] extern crate telegram_derive;
 
 pub mod ser;
 // pub mod de;

--- a/telegram/src/ser.rs
+++ b/telegram/src/ser.rs
@@ -140,7 +140,7 @@ impl<T: Serialize> Serialize for Vec<T> {
 }
 
 impl Serialize for Box<Any> {
-    fn serialize_to(&self, buffer: &mut Vec<u8>) -> Result<()> {
+    fn serialize_to(&self, buffer: &mut Vec<u8>) -> error::Result<()> {
         match self.downcast_ref::<Box<Serialize>>() {
             Some(as_ser) => as_ser.serialize_to(buffer),
 

--- a/telegram_codegen/src/generator.rs
+++ b/telegram_codegen/src/generator.rs
@@ -188,7 +188,18 @@ pub fn generate(filename: &Path, schema: Schema) -> error::Result<()> {
     for (module_name, module) in &modules {
         if let Some(ref module_name) = *module_name {
             // Open module
-            writeln!(f, "pub mod {} {{\n", module_name)?;
+            writeln!(f, "pub mod {} {{", module_name)?;
+        }
+
+        if module.types.values().any(|type_| {
+            type_.constructors.iter().any(|constructor| {
+                constructor.params.iter().any(|param| {
+                    param[..3] == "int" &&
+                        param[3..].parse::<u64>().map_or(false, |bitness| bitness >= 128)
+                })
+            })
+        }) {
+            writeln!(f, "use extprim::i128::i128;")?;
         }
 
         for (name, type_) in &module.types {
@@ -197,7 +208,7 @@ pub fn generate(filename: &Path, schema: Schema) -> error::Result<()> {
             // Open type
             if type_.constructors.len() == 1 {
                 // A single constructor is output as a struct
-                writeln!(f, "#[id = 0x{:x}]", type_.constructors[0].id)?;
+                writeln!(f, "#[id = \"0x{:x}\"]", type_.constructors[0].id)?;
 
                 if type_.constructors[0].params.is_empty() {
                     // A single constructor with no parameters is a unit
@@ -215,12 +226,12 @@ pub fn generate(filename: &Path, schema: Schema) -> error::Result<()> {
 
                 if constructor.params.is_empty() {
                     // No parameters
-                    writeln!(f, "  #[id = 0x{:x}]", constructor.id)?;
+                    writeln!(f, "  #[id = \"0x{:x}\"]", constructor.id)?;
                     writeln!(f, "  {},", constructor_name)?;
                 } else {
                     // Open constructor (if more than 1)
                     if type_.constructors.len() > 1 {
-                        writeln!(f, "  #[id = 0x{:x}]", constructor.id)?;
+                        writeln!(f, "  #[id = \"0x{:x}\"]", constructor.id)?;
                         writeln!(f, "  {} {{", constructor_name)?;
                     }
 

--- a/telegram_codegen/src/generator.rs
+++ b/telegram_codegen/src/generator.rs
@@ -194,8 +194,9 @@ pub fn generate(filename: &Path, schema: Schema) -> error::Result<()> {
         if module.types.values().any(|type_| {
             type_.constructors.iter().any(|constructor| {
                 constructor.params.iter().any(|param| {
-                    param[..3] == "int" &&
-                        param[3..].parse::<u64>().map_or(false, |bitness| bitness >= 128)
+                    param.kind.len() >= 3 &&
+                        &param.kind[..3] == "int" &&
+                        param.kind[3..].parse::<u64>().ok().map_or(false, |bitness| bitness >= 128)
                 })
             })
         }) {

--- a/telegram_derive/src/lib.rs
+++ b/telegram_derive/src/lib.rs
@@ -4,8 +4,10 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
+use std::u32;
+
 use proc_macro::TokenStream;
-use syn::{VariantData, Body, MetaItem, Lit};
+use syn::{VariantData, Body, MetaItem, Lit, StrStyle};
 
 #[proc_macro_derive(Serialize, attributes(id))]
 pub fn serialize(input: TokenStream) -> TokenStream {
@@ -47,10 +49,11 @@ fn impl_serialize(ast: &syn::MacroInput) -> quote::Tokens {
         match attr.value {
             MetaItem::NameValue(ref name, ref value) => {
                 if name.as_ref() == "id" {
-                    if let Lit::Int(value, _) = *value {
+                    if let Lit::Str(ref value, StrStyle::Cooked) = *value {
                         // Found an identifier
+                        let value = u32::from_str_radix(&value[2..], 16).unwrap();
                         id = Some(quote! {
-                            (#value as u32).serialize_to(buffer)?;
+                            #value.serialize_to(buffer)?;
                         });
 
                         break;


### PR DESCRIPTION
- Replace builtin i128-bit types by `extprim::i128::i128`;
- Use string representations of id in `#[id]` attributes;
- Remove a redundant use of `#![feature(concat_idents)]`.