### PR TITLE
Bump dependencies' versions

### DIFF
--- a/telegram/Cargo.toml
+++ b/telegram/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/telegram"
 repository = "https://github.com/mehcode/telegram-rs"
 
 [dependencies]
-byteorder = "1.0.0"
-error-chain = "0.9.0"
+byteorder = "1.1.0"
+error-chain = "0.10.0"
 extprim = "1.4.0"
 telegram_derive = "0.1.0"
 

--- a/telegram_codegen/Cargo.toml
+++ b/telegram_codegen/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/telegram_codegen"
 repository = "https://github.com/mehcode/telegram-rs"
 
 [dependencies]
-error-chain = "0.9.0"
-serde = "0.9.7"
-serde_derive = "0.9.7"
-serde_json = "0.9.6"
+error-chain = "0.10.0"
+serde = "1.0.10"
+serde_derive = "1.0.10"
+serde_json = "1.0.2"

--- a/telegram_codegen/src/error.rs
+++ b/telegram_codegen/src/error.rs
@@ -1,6 +1,8 @@
 error_chain! {
     foreign_links {
         Io(::std::io::Error);
+        ParseInt(::std::num::ParseIntError);
+
         SerdeJson(::serde_json::Error);
     }
 }

--- a/telegram_codegen/src/parser.rs
+++ b/telegram_codegen/src/parser.rs
@@ -11,7 +11,7 @@ pub struct Parameter {
 
 #[derive(Debug, Deserialize)]
 pub struct Constructor {
-    pub id: i32,
+    pub id: String,
     pub predicate: String,
     pub params: Vec<Parameter>,
 
@@ -21,7 +21,7 @@ pub struct Constructor {
 
 #[derive(Debug, Deserialize)]
 pub struct Method {
-    pub id: i32,
+    pub id: String,
     pub method: String,
     pub params: Vec<Parameter>,
 

--- a/telegram_derive/Cargo.toml
+++ b/telegram_derive/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/mehcode/telegram-rs"
 proc-macro = true
 
 [dependencies]
-syn = "0.10.5"
-quote = "0.3.10"
+syn = "0.11.11"
+quote = "0.3.15"

--- a/telegram_derive/src/lib.rs
+++ b/telegram_derive/src/lib.rs
@@ -15,7 +15,7 @@ pub fn serialize(input: TokenStream) -> TokenStream {
     let s = input.to_string();
 
     // Parse the string representation
-    let ast = syn::parse_macro_input(&s).unwrap();
+    let ast = syn::parse_derive_input(&s).unwrap();
 
     // Build the impl
     let gen = impl_serialize(&ast);
@@ -24,7 +24,7 @@ pub fn serialize(input: TokenStream) -> TokenStream {
     gen.parse().unwrap()
 }
 
-fn impl_serialize(ast: &syn::MacroInput) -> quote::Tokens {
+fn impl_serialize(ast: &syn::DeriveInput) -> quote::Tokens {
     let mut properties = Vec::new();
 
     match ast.body {


### PR DESCRIPTION
Not doing for hyper for now, because hyper 0.11 introduced many fundamental breaking changes.