### PR TITLE
Modify `telegram_codegen::translate` and friends

### DIFF
--- a/telegram/build.rs
+++ b/telegram/build.rs
@@ -5,11 +5,10 @@ use std::path::Path;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = Path::new(&out_dir).join("schema.rs");
 
-    telegram_codegen::translate("schema/schema.json", &dest_path).unwrap();
+    let dest_path = Path::new(&out_dir).join("schema.rs");
+    telegram_codegen::translate_from_json_file("schema/schema.json", &dest_path).unwrap();
 
     let dest_path = Path::new(&out_dir).join("mtproto_schema.rs");
-
-    telegram_codegen::translate("schema/mtproto-schema.json", &dest_path).unwrap();
+    telegram_codegen::translate_from_json_file("schema/mtproto-schema.json", &dest_path).unwrap();
 }

--- a/telegram_codegen/src/generator.rs
+++ b/telegram_codegen/src/generator.rs
@@ -141,7 +141,7 @@ fn to_constructor(
 }
 
 /// Generate Rust definitions to the file from the schema
-pub fn generate(filename: &Path, schema: Schema) -> error::Result<()> {
+pub fn generate<P: AsRef<Path>>(filename: P, schema: &Schema) -> error::Result<()> {
     let mut modules = HashMap::<Option<String>, Module>::new();
     let mut predicates = HashMap::<String, String>::new();
 

--- a/telegram_codegen/src/lib.rs
+++ b/telegram_codegen/src/lib.rs
@@ -8,22 +8,22 @@ extern crate serde_derive;
 
 extern crate serde_json;
 
+
 mod error;
 mod parser;
 mod generator;
 
 use std::fs::File;
 use std::path::Path;
-use std::io::Read;
 
-pub fn translate(input_filename: &str, output_filename: &Path) -> error::Result<()> {
-    let mut f = File::open(input_filename)?;
-    let mut s = String::new();
-    f.read_to_string(&mut s)?;
 
-    let s: parser::Schema = s.parse()?;
-
-    generator::generate(output_filename, s)?;
+pub fn translate_from_json_file<I, O>(input_filename: I, output_filename: O) -> error::Result<()>
+    where I: AsRef<Path>,
+          O: AsRef<Path>,
+{
+    let f = File::open(input_filename)?;
+    let s: parser::Schema = serde_json::from_reader(f)?;
+    generator::generate(output_filename, &s)?;
 
     Ok(())
 }


### PR DESCRIPTION
- Use a more descriptive name
- Generalize `&str` and `&Path` to `P: AsRef<Path>`
- Remove unnecessary reading to in-memory buffer