### PR TITLE
Simplify `telegram::Client` API

### DIFF
--- a/examples/create_auth_key/Cargo.toml
+++ b/examples/create_auth_key/Cargo.toml
@@ -7,6 +7,3 @@ workspace = "../../"
 extprim = "1.4.0"
 extprim_literals = "2.0.3"
 telegram = { path = "../../telegram" }
-hyper = "0.11"
-futures = "0.1"
-tokio-core = "0.1"

--- a/examples/create_auth_key/src/main.rs
+++ b/examples/create_auth_key/src/main.rs
@@ -1,16 +1,14 @@
 extern crate extprim;
 #[macro_use]
 extern crate extprim_literals;
-extern crate hyper;
 extern crate telegram;
-extern crate futures;
-extern crate tokio_core;
-
-use futures::Future;
-use tokio_core::reactor::Core;
 
 
 fn main() {
+    impl_main().unwrap()
+}
+
+fn impl_main() -> telegram::Result<()> {
     // Request for (p,q) Authorization
     // https://core.telegram.org/mtproto/samples-auth_key
 
@@ -35,16 +33,14 @@ fn main() {
     // [DEBUG] Step
     println!(" - Send {}\n", "http://149.154.167.50:443/api");
 
-    let mut core = Core::new().unwrap();
-    let client = telegram::Client::new(&core.handle());
-    let promise = client.request(req).map(|data| {
+    let mut client = telegram::Client::new()?;
+
+    client.send(req, |data| {
         // [DEBUG] Step
         println!(" - Receive");
 
         pprint(&data);
-    });
-
-    core.run(promise).unwrap();
+    })
 }
 
 fn pprint(buffer: &[u8]) {

--- a/telegram/src/client.rs
+++ b/telegram/src/client.rs
@@ -1,40 +1,51 @@
-use tokio::reactor::Handle;
 use futures::{future, Stream, Future};
-use ser::Serialize;
 use hyper::{self, Body};
 use hyper::client::HttpConnector;
-use request::Request;
+use tokio::reactor::Core;
+
 use error;
+use request::Request;
+use ser::Serialize;
+
 
 pub struct Client {
+    core: Core,
     http_client: hyper::Client<HttpConnector, Body>,
 }
 
 impl Client {
     /// Create a new Telegram client.
     #[inline]
-    pub fn new(handle: &Handle) -> Client {
-        Client {
-            http_client: hyper::Client::new(handle),
-        }
+    pub fn new() -> error::Result<Client> {
+        let core = Core::new()?;
+        let http_client = hyper::Client::new(&core.handle());
+
+        Ok(Client {
+            core: core,
+            http_client: http_client,
+        })
     }
 
-    // Send a constructed request using this Client.
-    pub fn request<T: Serialize>(
-        &self,
-        req: Request<T>,
-    ) -> Box<Future<Item = Vec<u8>, Error = error::Error>> {
-        let http_request = match req.to_http_request() {
-            Ok(req) => req,
-            Err(error) => return Box::new(future::err(error)),
-        };
+    /// Send a constructed request using this Client.
+    pub fn send<F, T, U>(&mut self, req: Request<T>, on_receive_handler: F) -> error::Result<U>
+        where F: FnOnce(Vec<u8>) -> U,
+              T: Serialize,
+    {
+        let future: Box<Future<Item = U, Error = error::Error>> =
+            match req.to_http_request() {
+                Ok(http_request) => {
+                    Box::new(self.http_client
+                        .request(http_request)
+                        .and_then(|res| res.body().concat2())
+                        .map(|data| data.to_vec())
+                        .map(on_receive_handler)
+                        .map_err(|err| err.into()))
+                },
+                Err(error) => {
+                    Box::new(future::err(error))
+                },
+            };
 
-        Box::new(
-            self.http_client
-                .request(http_request)
-                .and_then(|res| res.body().concat2())
-                .map(|data| data.to_vec())
-                .map_err(|err| err.into())
-        )
+        self.core.run(future)
     }
 }

--- a/telegram/src/lib.rs
+++ b/telegram/src/lib.rs
@@ -15,6 +15,7 @@ mod client;
 mod request;
 
 pub use client::Client;
+pub use error::{Error, Result};
 pub use request::Request;
 
 #[allow(non_camel_case_types)]

--- a/telegram/src/request.rs
+++ b/telegram/src/request.rs
@@ -1,7 +1,9 @@
-use ser::Serialize;
-use hyper;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use hyper;
+
 use error;
+use ser::Serialize;
 
 #[derive(Debug)]
 pub struct Request<T: Serialize> {


### PR DESCRIPTION
`futures`, `tokio` and `hyper` usages are implementation details.